### PR TITLE
fix: unlock phone number field when buyer has no saved phone number

### DIFF
--- a/src/sections/tickets/components/phone-input.jsx
+++ b/src/sections/tickets/components/phone-input.jsx
@@ -52,8 +52,13 @@ const phoneInputStyles = `
 `;
 
 export const PhoneInputCustom = ({ name, label, readOnly, disabled, ...other }) => {
-  const { control, watch } = useFormContext();
+  const { control, watch, getValues } = useFormContext();
   const theme = useTheme();
+
+  // If readOnly is requested, only lock the field when it already has a value.
+  // This allows buyers with no saved phone number to still type one in.
+  const currentValue = getValues(name);
+  const isLocked = readOnly && !!currentValue;
 
   // Add style element for custom PhoneInput styles
   useEffect(() => {
@@ -107,8 +112,8 @@ export const PhoneInputCustom = ({ name, label, readOnly, disabled, ...other }) 
               backgroundColor: 'transparent',
               color: theme.palette.text.primary,
             }}
-            disabled={disabled || readOnly}
-            readOnly={readOnly}
+            disabled={disabled || isLocked}
+            readOnly={isLocked}
             {...other}
           />
           {error && (


### PR DESCRIPTION
## Problem
When a buyer marked themselves as an attendee (Buyer's Ticket), the phone number field was being set to `disabled` even when it was empty. This prevented customers with no saved phone number from typing one in, blocking them from completing checkout.

**Root cause:** `disabled={disabled || readOnly}` in `phone-input.jsx` — when `readOnly=true` was passed, it also triggered `disabled=true`.

## Fix
The field is now only locked when `readOnly=true` AND the field already has a value. If the field is empty, it remains typeable.

- Pre-filled phone number → locked (can't edit) ✅
- Empty phone number → typeable (can enter number) ✅

## Files Changed
- `src/sections/tickets/components/phone-input.jsx`