### PR TITLE
fix: enable add-on creation when editing a ticket

### DIFF
--- a/src/sections/events/ticket-types/ticket-table-row.jsx
+++ b/src/sections/events/ticket-types/ticket-table-row.jsx
@@ -170,6 +170,7 @@ export default function TicketTableRow({
   } = row;
 
   const confirm = useBoolean();
+  const addOn = useBoolean();
   const popover = usePopover();
   const smDown = useResponsive('down', 'sm');
   const { enqueueSnackbar } = useSnackbar();
@@ -1184,7 +1185,7 @@ export default function TicketTableRow({
           )}
 
           {/* Step 2: Add Ons */}
-          {activeStep === 1 && <AddOn />}
+          {activeStep === 1 && <AddOn addOn={addOn} />}
         </DialogContent>
 
         <DialogActions


### PR DESCRIPTION
## Summary
- The \"Create new add-on\" button was non-functional in the Edit Ticket dialog
- Root cause: `AddOn` component was rendered without the required `addOn` prop in the edit flow, while the create flow passed it correctly
- Fix: added a `useBoolean()` hook for `addOn` in `TicketTableRow` and passed it to `<AddOn addOn={addOn} />`

## Changes
- `ticket-table-row.jsx`: added `const addOn = useBoolean()` and passed it to `<AddOn addOn={addOn} />` at step 2 of the edit dialog